### PR TITLE
Fix unpkg url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ npm start
 
 ### Script tag
 
-- Put `<script src='https://unpkg.com/stencil-payment@latest/dist/payment.js'></script>` in the head of your index.html
+- Put `<script src='https://unpkg.com/stencil-payment@latest/dist/stpayment.js'></script>` in the head of your index.html
 - Then you can use the element `<st-payment>` anywhere in your template, JSX, html etc
 
 ### Node Modules


### PR DESCRIPTION
The example of using library via unpkg.com pointed to payment.js instead of stpayment.js. Trying to load payment.js returns this error instead of the script:

`Cannot find module "/dist/payment.js" in package stencil-payment@0.0.3`